### PR TITLE
Fix calendar component and add use shared single redux store.

### DIFF
--- a/web/js/components/Press/AcclaimsList.jsx
+++ b/web/js/components/Press/AcclaimsList.jsx
@@ -7,7 +7,7 @@ import { AutoSizer, CellMeasurer, List } from 'react-virtualized';
 
 import AcclaimsListItem from '@/js/components/Press/AcclaimsListItem.jsx';
 
-class AcclaimsListPresentation extends React.Component {
+class ConnectedAcclaimsList extends React.Component {
     componentWillMount() { this.props.fetchAcclaims(); }
 
     _renderAcclaimItem(key, index, style) {
@@ -38,15 +38,15 @@ class AcclaimsListPresentation extends React.Component {
                                     width={width}
                                 >
                                     {
-                                        ({getRowHeight}) => {
-                                            return <List
+                                        ({getRowHeight}) => (
+                                            <List
                                                 height={height}
                                                 width={width}
                                                 rowCount={numRows}
                                                 rowHeight={getRowHeight}
                                                 rowRenderer={this.rowItemRenderer.bind(this)}
-                                            />;
-                                        }
+                                            />
+                                        )
                                     }
                                 </CellMeasurer>
                             );
@@ -62,27 +62,22 @@ function getAcclaims() {
     return axios.get('/api/acclaims');
 }
 
-const mapStateToProps = state => {
-    return { acclaims: state.acclaims };
-};
+const mapStateToProps = state => ({ acclaims: state.press_acclaimsList.acclaims });
 
-const mapDispatchToProps = dispatch => {
-    return {
-        fetchAcclaims: () => {
-            dispatch({ type: 'PRESS--FETCHING_ACCLAIMS' });
-            getAcclaims().then(
-                response => {
-                    dispatch({
-                        type: 'PRESS--FETCH_ACCLAIMS_SUCCESS',
-                        acclaims: response.data,
-                    });
-                }
-            );
-        },
-    };
-};
+const mapDispatchToProps = (dispatch) => ({
+    fetchAcclaims: () => {
+        dispatch({ type: 'PRESS--FETCHING_ACCLAIMS' });
+
+        getAcclaims().then(
+            (response) => dispatch({
+                type: 'PRESS--FETCH_ACCLAIMS_SUCCESS',
+                acclaims: response.data,
+            })
+        );
+    },
+});
 
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(AcclaimsListPresentation);
+)(ConnectedAcclaimsList);

--- a/web/js/components/Press/AcclaimsList.jsx
+++ b/web/js/components/Press/AcclaimsList.jsx
@@ -29,28 +29,26 @@ class ConnectedAcclaimsList extends React.Component {
             <div className="acclaims-list">
                 <AutoSizer disableWidth>
                     {
-                        ({height, width}) => {
-                            return (
-                                <CellMeasurer
-                                    cellRenderer={this.cellItemRenderer.bind(this)}
-                                    columnCount={1}
-                                    rowCount={numRows}
-                                    width={width}
-                                >
-                                    {
-                                        ({getRowHeight}) => (
-                                            <List
-                                                height={height}
-                                                width={width}
-                                                rowCount={numRows}
-                                                rowHeight={getRowHeight}
-                                                rowRenderer={this.rowItemRenderer.bind(this)}
-                                            />
-                                        )
-                                    }
-                                </CellMeasurer>
-                            );
-                        }
+                        ({height, width}) => (
+                            <CellMeasurer
+                                cellRenderer={this.cellItemRenderer.bind(this)}
+                                columnCount={1}
+                                rowCount={numRows}
+                                width={width}
+                            >
+                                {
+                                    ({getRowHeight}) => (
+                                        <List
+                                            height={height}
+                                            width={width}
+                                            rowCount={numRows}
+                                            rowHeight={getRowHeight}
+                                            rowRenderer={this.rowItemRenderer.bind(this)}
+                                        />
+                                    )
+                                }
+                            </CellMeasurer>
+                        )
                     }
                 </AutoSizer>
             </div>
@@ -64,12 +62,12 @@ function getAcclaims() {
 
 const mapStateToProps = state => ({ acclaims: state.press_acclaimsList.acclaims });
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
     fetchAcclaims: () => {
         dispatch({ type: 'PRESS--FETCHING_ACCLAIMS' });
 
         getAcclaims().then(
-            (response) => dispatch({
+            response => dispatch({
                 type: 'PRESS--FETCH_ACCLAIMS_SUCCESS',
                 acclaims: response.data,
             })

--- a/web/js/components/Press/Press.jsx
+++ b/web/js/components/Press/Press.jsx
@@ -2,14 +2,10 @@ import '@/less/Press/press.less';
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { createStore } from 'redux';
 
 import AcclaimsList from '@/js/components/Press/AcclaimsList.jsx';
-import { acclaimsListReducer } from '@/js/components/Press/reducers.js';
 
-const store = createStore(acclaimsListReducer);
-
-const Press = () => (
+const Press = ({ store }) => (
     <Provider store={store}>
         <div className="press">
             <AcclaimsList />

--- a/web/js/components/Schedule/EventList.jsx
+++ b/web/js/components/Schedule/EventList.jsx
@@ -11,7 +11,7 @@ import EventItem from '@/js/components/Schedule/EventItem.jsx';
 import EventMonthItem from '@/js/components/Schedule/EventMonthItem.jsx';
 import { googleAPI } from '@/js/services/GoogleAPI.js';
 
-class EventListPresentation extends React.Component {
+class ConnectedEventList extends React.Component {
     componentWillMount() { this.props.fetchEvents(); }
 
     componentDidUpdate() { this.List.scrollToRow(this.props.currentScrollIndex || 0); }
@@ -47,8 +47,8 @@ class EventListPresentation extends React.Component {
                                     width={width}
                                 >
                                     {
-                                        ({getRowHeight}) => {
-                                            return <List
+                                        ({getRowHeight}) => (
+                                            <List
                                                 ref={div => this.List = div}
                                                 height={height}
                                                 width={width}
@@ -56,8 +56,8 @@ class EventListPresentation extends React.Component {
                                                 rowHeight={getRowHeight}
                                                 rowRenderer={this.rowItemRenderer.bind(this)}
                                                 scrollToAlignment='start'
-                                            />;
-                                        }
+                                            />
+                                        )
                                     }
                                 </CellMeasurer>
                             );
@@ -94,4 +94,4 @@ const mapDispatchToProps = dispatch => {
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(EventListPresentation);
+)(ConnectedEventList);

--- a/web/js/components/Schedule/EventList.jsx
+++ b/web/js/components/Schedule/EventList.jsx
@@ -38,30 +38,28 @@ class ConnectedEventList extends React.Component {
             <div className="event-list">
                 <AutoSizer>
                     {
-                        ({height, width}) => {
-                            return (
-                                <CellMeasurer
-                                    cellRenderer={this.cellItemRenderer.bind(this)}
-                                    columnCount={1}
-                                    rowCount={numRows}
-                                    width={width}
-                                >
-                                    {
-                                        ({getRowHeight}) => (
-                                            <List
-                                                ref={div => this.List = div}
-                                                height={height}
-                                                width={width}
-                                                rowCount={numRows}
-                                                rowHeight={getRowHeight}
-                                                rowRenderer={this.rowItemRenderer.bind(this)}
-                                                scrollToAlignment='start'
-                                            />
-                                        )
-                                    }
-                                </CellMeasurer>
-                            );
-                        }
+                        ({height, width}) => (
+                            <CellMeasurer
+                                cellRenderer={this.cellItemRenderer.bind(this)}
+                                columnCount={1}
+                                rowCount={numRows}
+                                width={width}
+                            >
+                                {
+                                    ({getRowHeight}) => (
+                                        <List
+                                            ref={div => this.List = div}
+                                            height={height}
+                                            width={width}
+                                            rowCount={numRows}
+                                            rowHeight={getRowHeight}
+                                            rowRenderer={this.rowItemRenderer.bind(this)}
+                                            scrollToAlignment='start'
+                                        />
+                                    )
+                                }
+                            </CellMeasurer>
+                        )
                     }
                 </AutoSizer>
             </div>
@@ -75,21 +73,22 @@ function getInitialEventItems() {
     ));
 }
 
-const mapStateToProps = state => {
-    return {
-        eventItems: state.schedule_eventItems.items,
-        currentScrollIndex: state.schedule_eventItems.currentScrollIndex,
-    };
-};
+const mapStateToProps = state => ({
+    eventItems: state.schedule_eventItems.items,
+    currentScrollIndex: state.schedule_eventItems.currentScrollIndex,
+});
 
-const mapDispatchToProps = dispatch => {
-    return { fetchEvents: () => {
-        getInitialEventItems().then(items => {
-            dispatch({ type: 'SCHEDULE--FETCH_EVENTS_SUCCESS', fetchedEvents: items });
-        });
+const mapDispatchToProps = dispatch => ({
+    fetchEvents: () => {
+        getInitialEventItems().then(items => (
+            dispatch({
+                type: 'SCHEDULE--FETCH_EVENTS_SUCCESS',
+                fetchedEvents: items,
+            })
+        ));
         dispatch({ type: 'SCHEDULE--FETCHING_EVENTS' });
-    }};
-};
+    }
+});
 
 export default connect(
     mapStateToProps,

--- a/web/js/components/Schedule/Schedule.jsx
+++ b/web/js/components/Schedule/Schedule.jsx
@@ -7,19 +7,17 @@ import { Provider } from 'react-redux';
 import SycCalendar from '@/js/components/Schedule/SycCalendar.jsx';
 import EventList from '@/js/components/Schedule/EventList.jsx';
 
-const Schedule = ({store}) => {
-    return (
-        <Provider store={store}>
-            <div className="schedule">
-                <div className="schedule__calendar">
-                    <SycCalendar />
-                </div>
-                <div className="schedule__events">
-                    <EventList />
-                </div>
+const Schedule = ({store}) => (
+    <Provider store={store}>
+        <div className="schedule">
+            <div className="schedule__calendar">
+                <SycCalendar />
             </div>
-        </Provider>
-    );
-}
+            <div className="schedule__events">
+                <EventList />
+            </div>
+        </div>
+    </Provider>
+);
 
 export default Schedule;

--- a/web/js/components/Schedule/SycCalendar.jsx
+++ b/web/js/components/Schedule/SycCalendar.jsx
@@ -6,31 +6,25 @@ import { connect } from 'react-redux';
 
 import Calendar from 'rc-calendar';
 
-class SycCalendarPresentation extends React.Component {
-    render() {
-        return <Calendar
-            prefixCls='syc-calendar'
-            showDateInput={false}
-            showToday={false}
-            enablePrev={true}
-            enableNext={true}
-            onChange={this.props.onChange}
-            value={this.props.date}
-        />
-    }
-}
+const ConnectedSycCalendar = ({ date, onChange }) => (
+    <Calendar
+        prefixCls='syc-calendar'
+        showDateInput={false}
+        showToday={false}
+        enablePrev={true}
+        enableNext={true}
+        onChange={onChange}
+        value={date}
+    />
+);
 
-const mapStateToProps = (state) => {
-    return state;
-};
+const mapStateToProps = state => ({ date: state.schedule_date });
 
-const mapDispatchToProps = (dispatch) => {
-    return {
-        onChange: date => dispatch({type: 'SCHEDULE--UPDATE_DATE', date})
-    };
-};
+const mapDispatchToProps = dispatch => ({
+    onChange: date => dispatch({type: 'SCHEDULE--UPDATE_DATE', date})
+});
 
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(SycCalendarPresentation);
+)(ConnectedSycCalendar);

--- a/web/js/components/Schedule/reducers.js
+++ b/web/js/components/Schedule/reducers.js
@@ -29,6 +29,9 @@ export const eventItemsReducer = (state = {
             return state.isFetching ? state : { ...state, isFetching: true }
         case 'SCHEDULE--UPDATE_DATE':
             if (!state.eventItemsWrapper || state.isFetching) return state;
+
+            // On date update, we want to scroll the events list to the start
+            // of the selected month.
             const month = action.date.format('MMMM');
             return {
                 ...state,

--- a/web/js/components/Schedule/reducers.js
+++ b/web/js/components/Schedule/reducers.js
@@ -4,7 +4,7 @@ import { EventItemsWrapper } from '@/js/components/Schedule/EventItemsWrapper.js
 
 export const dateReducer = (state = moment(), action) => {
     switch (action.type) {
-        case 'UPDATE_DATE':
+        case 'SCHEDULE--UPDATE_DATE':
             return action.date;
         default:
             return state;

--- a/web/js/main.jsx
+++ b/web/js/main.jsx
@@ -4,7 +4,7 @@ import { Router, Route, IndexRoute, IndexRedirect, browserHistory } from 'react-
 import 'velocity-animate';
 import 'velocity-animate/velocity.ui';
 
-import createStore from '@/js/store.js';
+import createSycStore from '@/js/store.js';
 
 import App from '@/js/components/App/App.jsx';
 import Home from '@/js/components/Home/Home.jsx';
@@ -21,7 +21,7 @@ import Photos from '@/js/components/Media/Photos/Photos.jsx';
 main();
 
 function main() {
-    const store = createStore();
+    const store = createSycStore();
     ReactDOM.render((
         <Router history={browserHistory}>
             <Route path='/' component={App}>

--- a/web/js/store.js
+++ b/web/js/store.js
@@ -1,3 +1,12 @@
+/**
+ * This is the global redux store.
+ *
+ * It takes reducers from different pages, combines them into a single reducer,
+ * and creates a combined store.
+ *
+ * We make sure to namespace the states by their corresponding reducers.
+ */
+
 import { combineReducers, createStore } from 'redux';
 import { acclaimsListReducer } from '@/js/components/Press/reducers.js';
 import { dateReducer, eventItemsReducer } from '@/js/components/Schedule/reducers.js';

--- a/web/js/store.js
+++ b/web/js/store.js
@@ -1,9 +1,11 @@
 import { combineReducers, createStore } from 'redux';
+import { acclaimsListReducer } from '@/js/components/Press/reducers.js';
 import { dateReducer, eventItemsReducer } from '@/js/components/Schedule/reducers.js';
 
 const reducersMap = {
     schedule_date: dateReducer,
     schedule_eventItems: eventItemsReducer,
-}
+    press_acclaimsList: acclaimsListReducer,
+};
 
 export default () => createStore(combineReducers(reducersMap));


### PR DESCRIPTION
I had messed up the state -> props part of the calendar component when I was working on the press page. I accidentally committed a half-baked global redux store. This basically makes it so that both Press and Schedule use the same redux store.