### PR TITLE
Selected event item indicator

### DIFF
--- a/web/js/components/Schedule/EventItem.jsx
+++ b/web/js/components/Schedule/EventItem.jsx
@@ -1,11 +1,12 @@
 import '@/less/Schedule/event-item.less';
 
-import _ from 'lodash'
 import React from 'react';
 import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import moment from 'moment-timezone';
 import classNames from 'classnames';
+
+import { titleCase } from '@/js/utils.js';
 
 const DateContainer = ({ dateTime }) => (
     <div className="event-item__date-container">
@@ -21,14 +22,9 @@ const DateContainer = ({ dateTime }) => (
 );
 
 const EventName = ({ dateTime, name, storeScroll, gridState, handleSelect }) => (
-    <Link
-        to={`/schedule/${dateTime.format('YYYY-MM-DD')}`}
-        onClick={handleSelect}
-    >
-        <div className="event-item__info-name">
-            {name}
-        </div>
-    </Link>
+    <div className="event-item__info-name">
+        {name}
+    </div>
 );
 
 const EventBody = ({ program, collaborators }) => (
@@ -59,26 +55,26 @@ const EventItem = ({
 }) => {
     const time = event.dateTime.format('h:mm z');
     return (
-        <div
-            className={classNames('event-item', { 'event-item--active': active })}
+        <Link
+            to={`/schedule/${event.dateTime.format('YYYY-MM-DD')}`}
+            onClick={handleSelect}
             style={style}
         >
-            <DateContainer dateTime={event.dateTime} />
-            <div className="event-item__info">
-                <EventName
-                    dateTime={event.dateTime}
-                    name={event.name}
-                    gridState={gridState}
-                    handleSelect={handleSelect}
-                />
-                <div className="event-item__info-time">
-                    {time}
-                </div>
-                <div className="event-item__info-type">
-                    {_.startCase(event.eventType)}
+            <div
+                className={classNames('event-item', { 'event-item--active': active })}
+            >
+                <DateContainer dateTime={event.dateTime} />
+                <div className="event-item__info">
+                    <EventName name={event.name} />
+                    <div className="event-item__info-time">
+                        {time}
+                    </div>
+                    <div className="event-item__info-type">
+                        {titleCase(event.eventType)}
+                    </div>
                 </div>
             </div>
-        </div>
+        </Link>
     );
 }
 

--- a/web/js/components/Schedule/EventItem.jsx
+++ b/web/js/components/Schedule/EventItem.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import moment from 'moment-timezone';
+import classNames from 'classnames';
 
 const DateContainer = ({ dateTime }) => (
     <div className="event-item__date-container">
@@ -54,10 +55,14 @@ const EventItem = ({
     style,
     gridState,
     handleSelect,
+    active,
 }) => {
     const time = event.dateTime.format('h:mm z');
     return (
-        <div className="event-item" style={style}>
+        <div
+            className={classNames('event-item', { 'event-item--active': active })}
+            style={style}
+        >
             <DateContainer dateTime={event.dateTime} />
             <div className="event-item__info">
                 <EventName

--- a/web/js/components/Schedule/EventItem.jsx
+++ b/web/js/components/Schedule/EventItem.jsx
@@ -21,11 +21,7 @@ const DateContainer = ({ dateTime }) => (
     </div>
 );
 
-const EventName = ({ dateTime, name, storeScroll, gridState, handleSelect }) => (
-    <div className="event-item__info-name">
-        {name}
-    </div>
-);
+const EventName = ({ name }) => <div className="event-item__info-name">{name}</div>;
 
 const EventBody = ({ program, collaborators }) => (
     <div className="event-item__info-body">
@@ -60,9 +56,7 @@ const EventItem = ({
             onClick={handleSelect}
             style={style}
         >
-            <div
-                className={classNames('event-item', { 'event-item--active': active })}
-            >
+            <div className={classNames('event-item', { 'event-item--active': active })}>
                 <DateContainer dateTime={event.dateTime} />
                 <div className="event-item__info">
                     <EventName name={event.name} />

--- a/web/js/components/Schedule/EventList.jsx
+++ b/web/js/components/Schedule/EventList.jsx
@@ -1,7 +1,5 @@
 import '@/less/Schedule/event-list.less';
 
-// should we just use es6 array functions instead of lodash?
-import _ from 'lodash';
 import moment from 'moment-timezone';
 import React from 'react';
 import { connect } from 'react-redux';

--- a/web/js/components/Schedule/EventList.jsx
+++ b/web/js/components/Schedule/EventList.jsx
@@ -4,11 +4,21 @@ import moment from 'moment-timezone';
 import React from 'react';
 import { connect } from 'react-redux';
 import { AutoSizer, CellMeasurer, CellMeasurerCache, List } from 'react-virtualized';
+import { easeQuadOut } from 'd3-ease';
+
 import EventItem from '@/js/components/Schedule/EventItem.jsx';
 import EventMonthItem from '@/js/components/Schedule/EventMonthItem.jsx';
-import { dispatchSelectEvent, dispatchAnimateStart, dispatchAnimateFinish } from '@/js/components/Schedule/actions.js';
+import {
+    dispatchSelectEvent,
+    dispatchAnimateStart,
+    dispatchAnimateFinish
+} from '@/js/components/Schedule/actions.js';
 import animateFn from '@/js/components/animate.js';
-import { easeQuadOut } from 'd3-ease';
+
+// How much less to scroll than the target offset when scrolling to an element.
+// This leaves a bit of room at the top, so that the currently selected element
+// isn't right against the top.
+const TARGET_OFFSET_MARGIN = 120;
 
 const cache = new CellMeasurerCache({ fixedWidth: true });
 
@@ -41,11 +51,11 @@ class ConnectedEventList extends React.Component {
         this.props.dispatchAnimateStart();
         animateFn(
             this.currentOffset,
-            targetOffset,
+            targetOffset - TARGET_OFFSET_MARGIN,
             500,
-            (position) => this.List.scrollToPosition(position),
+            position => this.List.scrollToPosition(position),
             easeQuadOut,
-            () => {this.props.dispatchAnimateFinish();}
+            () => this.props.dispatchAnimateFinish()
         );
     }
 

--- a/web/js/components/Schedule/EventList.jsx
+++ b/web/js/components/Schedule/EventList.jsx
@@ -19,6 +19,7 @@ class ConnectedEventList extends React.Component {
         super(props, context);
         this._renderEventItem = this._renderEventItem.bind(this);
 
+        // Current scroll offset of the list.
         this.currentOffset = 0;
     }
 
@@ -30,7 +31,6 @@ class ConnectedEventList extends React.Component {
 
         if (this.props.params.date) {
             const scrollIndex = this._getScrollIndex();
-            this.currentRow = scrollIndex;
             this.List.scrollToPosition(this.List.getOffsetForRow({ index: scrollIndex }));
         } else {
             this.List.scrollToRow(0);
@@ -77,9 +77,8 @@ class ConnectedEventList extends React.Component {
             style={style}
             measure={measure}
             gridState={this.List && this.List.Grid.state}
-            handleSelect={(e) => {
-                this.props.dispatchSelectEvent(item);
-            }}
+            handleSelect={e => this.props.dispatchSelectEvent(item)}
+            active={item.id === this.props.currentItem.id}
         />;
     }
 
@@ -129,6 +128,7 @@ class ConnectedEventList extends React.Component {
 
 const mapStateToProps = state => ({
     eventItems: state.schedule_eventItems.items,
+    currentItem: state.schedule_eventItems.currentItem,
     hasEventBeenSelected: state.schedule_eventItems.hasEventBeenSelected,
 });
 

--- a/web/js/components/Schedule/utils.js
+++ b/web/js/components/Schedule/utils.js
@@ -59,4 +59,4 @@ export const transformGCalEventsToListItems = (events) => {
 
         return [ ...runningEventsArr, ...nextEventsArr ];
     }, []);
-}
+};

--- a/web/js/utils.js
+++ b/web/js/utils.js
@@ -1,0 +1,1 @@
+export const titleCase = str => `${str[0].toUpperCase()}${str.substring(1)}`;

--- a/web/less/Schedule/event-details.less
+++ b/web/less/Schedule/event-details.less
@@ -10,4 +10,5 @@
 .event-map {
     height: 300px;
     margin: 25px 0 0;
+    width: 100%;
 }

--- a/web/less/Schedule/event-item.less
+++ b/web/less/Schedule/event-item.less
@@ -10,6 +10,16 @@
     align-items: center;
 }
 
+.event-item--active {
+    background-color: @light-blue;
+    color: white;
+
+    .event-item__date {
+        background-color: white;
+        color: @light-blue;
+    }
+}
+
 .event-item__date-container {
     flex: 0 0 100px;
 }

--- a/web/less/Schedule/event-item.less
+++ b/web/less/Schedule/event-item.less
@@ -4,10 +4,11 @@
 @date-container-dimension: 107px;
 
 .event-item {
-    padding-top: 30px;
+    padding: 30px 0 30px 10px;
     display: flex;
     max-width: 780px;
     font-family: @lato1;
+    align-items: center;
 }
 
 .event-link {
@@ -43,8 +44,7 @@
 
 .event-item__info {
     flex: 1 1 auto;
-    padding-left: 35px;
-    margin-bottom: 50px;
+    padding: 0 0 0 35px;
 }
 
 .event-item__info-name {

--- a/web/less/Schedule/event-item.less
+++ b/web/less/Schedule/event-item.less
@@ -6,17 +6,8 @@
 .event-item {
     padding: 30px 0 30px 10px;
     display: flex;
-    max-width: 780px;
     font-family: @lato1;
     align-items: center;
-}
-
-.event-link {
-    height: 100%;
-}
-
-.event-single {
-    width: 100%;
 }
 
 .event-item__date-container {

--- a/web/less/Schedule/event-item.less
+++ b/web/less/Schedule/event-item.less
@@ -1,23 +1,19 @@
 @import '../colors.less';
 @import '../fonts.less';
+@import '../mixins.less';
 
 @date-container-dimension: 107px;
 
 .event-item {
-    padding: 30px 0 30px 10px;
+    padding: 30px 0 30px 30px;
     display: flex;
     font-family: @lato1;
     align-items: center;
 }
 
 .event-item--active {
-    background-color: @light-blue;
-    color: white;
-
-    .event-item__date {
-        background-color: white;
-        color: @light-blue;
-    }
+    background-color: #d1cfe2;
+    color: @light-blue;
 }
 
 .event-item__date-container {

--- a/web/less/Schedule/event-month-item.less
+++ b/web/less/Schedule/event-month-item.less
@@ -1,4 +1,5 @@
 @import '../fonts.less';
+@import '../colors.less';
 
 .event-month-item {
     font-family: @lato2;


### PR DESCRIPTION
- Add `active` prop and class to `EventItem`, with corresponding styles.
- Moved the `<Link>` to wrap the entire item (still inside `EventItem`).
- Added a `titleCase()` utility function so as to not need lodash for something so simple.
- Added a top offset for the target scrollOffset, so that the active item isn't right up against the top

![screen shot 2017-09-20 at 10 10 49 pm](https://user-images.githubusercontent.com/1166548/30679774-a48f9f40-9e50-11e7-88a3-f09447fb151d.png)
